### PR TITLE
fixed y-axis label color issue

### DIFF
--- a/lib/src/base.dart
+++ b/lib/src/base.dart
@@ -1143,7 +1143,7 @@ class _TwoAxisChart extends Chart {
     // y-axis labels.
 
     _axesContext
-        ..fillStyle = _options['xAxis']['labels']['style']['color']
+        ..fillStyle = _options['yAxis']['labels']['style']['color']
         ..font = _getFont(_options['yAxis']['labels']['style'])
         ..textAlign = 'right'
         ..textBaseline = 'middle';


### PR DESCRIPTION
A typo in the options code made the y-axis to always have the same color as the x-axis.